### PR TITLE
Hotfix: remove core from location catch-all

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -70,7 +70,14 @@ http {
             alias /var/www/frontera/portal/static;
         }
 
-        location ~ ^/(core|auth|workbench|tickets|accounts|api|login|webhooks) {
+        location /core {
+            uwsgi_read_timeout 60s;
+            uwsgi_send_timeout 60s;
+            uwsgi_pass  portal_core;
+            include     /etc/nginx/uwsgi_params;
+        }
+
+        location ~ ^/(auth|workbench|tickets|accounts|api|login|webhooks) {
             uwsgi_read_timeout 60s;
             uwsgi_send_timeout 60s;
             uwsgi_pass  portal_core;


### PR DESCRIPTION
Fixes an issue where including `core` in the `location` catch-all in `nginx.conf` was preventing access to `/core/static` and `/core/media`.

From [DigitalOcean](https://www.digitalocean.com/community/tutorials/understanding-nginx-server-and-location-block-selection-algorithms):

> If no exact (with the = modifier) location block matches are found, Nginx then moves on to evaluating non-exact prefixes. It discovers the longest matching prefix location for the given request URI, which it then evaluates as follows:
> 
>     - If the longest matching prefix location has the ^~ modifier, then Nginx will immediately end its search and select this location to serve the request.
> 
>     - If the longest matching prefix location does not use the ^~ modifier, the match is stored by Nginx for the moment so that the focus of the search can be shifted.
> 
> After the longest matching prefix location is determined and stored, Nginx moves on to evaluating the regular expression locations (both case sensitive and insensitive). If there are any regular expression locations within the longest matching prefix location, Nginx will move those to the top of its list of regex locations to check. Nginx then tries to match against the regular expression locations sequentially. The first regular expression location that matches the request URI is immediately selected to serve the request.

So, `location ~ ^/(core...)` was overwriting `location /core/static`.