### PR TITLE
Update Makefile to enforce fresh collectstatic action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ deploy-core:
 	$(DOCKER_COMPOSE) stop core
 	$(DOCKER_COMPOSE) up -d
 	docker exec portal_django python3 manage.py migrate
-	docker exec portal_django python3 manage.py collectstatic --noinput
+	docker exec portal_django python3 manage.py collectstatic --noinput --clear
 	$(DOCKER_COMPOSE) restart nginx
 
 .PHONY: deploy-cms
@@ -18,7 +18,7 @@ deploy-cms:
 	$(DOCKER_COMPOSE) stop cms
 	$(DOCKER_COMPOSE) up -d
 	docker exec portal_cms python3 manage.py migrate
-	docker exec portal_cms python3 manage.py collectstatic --noinput
+	docker exec portal_cms python3 manage.py collectstatic --noinput --clear
 	$(DOCKER_COMPOSE) restart nginx
 
 .PHONY: deploy-all
@@ -27,9 +27,9 @@ deploy-all:
 	$(DOCKER_COMPOSE) stop
 	$(DOCKER_COMPOSE) up -d
 	docker exec portal_django python3 manage.py migrate
-	docker exec portal_django python3 manage.py collectstatic --noinput
+	docker exec portal_django python3 manage.py collectstatic --noinput --clear
 	docker exec portal_cms python3 manage.py migrate
-	docker exec portal_cms python3 manage.py collectstatic --noinput
+	docker exec portal_cms python3 manage.py collectstatic --noinput --clear
 	$(DOCKER_COMPOSE) restart nginx
 
 .PHONY: deploy-docs


### PR DESCRIPTION
Issue: The Django `collectstatic` feature will *not* overwrite a file that already exists in the static files directory by default. If it finds a new, uncollected file it will be copied over. However, if it finds a new version of an existing file, it will ignore the new file in favor of keeping the old. Due to the way the code is now built and shared between containers, there needs to be a forced collection of the static files upon deployment to ensure the latest code is being picked up.

Solution: Adding the `--clear` option to the collectstatic command will force django to delete the contents of `STATICFILESDIR` before executing the collectstatic command, eliminating the problem.