### PR TITLE
Add gzip configuration for static assets.

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -14,6 +14,11 @@ http {
     ssl_session_cache   shared:SSL:10m;
     ssl_session_timeout 10m;
 
+    gzip on;
+    gzip_comp_level 6;
+    gzip_vary on;
+    gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/rss+xml text/javascript image/svg+xml application/vnd.ms-fontobject application/x-font-ttf font/opentype;
+
     charset  utf-8;
 
     # Extra slashes matter to Agave


### PR DESCRIPTION
Using gzip to compress our static assets before serving them will dramatically reduce the bundle size and improve time-to-interact for users on slower connections.