### PR TITLE
task/FP-442: Pull and restart workers and websockets when deploy-core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ DOCKER_COMPOSE :=  docker-compose ${BASE_COMPOSE} ${COMPOSE_OVERRIDE} --env-file
 
 .PHONY: deploy-core
 deploy-core:
-	$(DOCKER_COMPOSE) pull core
-	$(DOCKER_COMPOSE) stop core
+	$(DOCKER_COMPOSE) pull core websockets workers
+	$(DOCKER_COMPOSE) stop core websockets workers
 	$(DOCKER_COMPOSE) up -d
 	docker exec portal_django python3 manage.py migrate
 	docker exec portal_django python3 manage.py collectstatic --noinput


### PR DESCRIPTION
### Overview
The `deploy-core` make action does not restart workers or websockets, so if only that action is taken then the latest changes will not be picked up by websockets or workers. This allows all services that depend on the core portal image to pull and restart on the deploy-core action.

### Jira Task

- [FP-442](https://jira.tacc.utexas.edu/browse/FP-442)

### Notes
This will be used live by https://dev.cep.tacc.utexas.edu [here](https://github.com/TACC/Core-Portal-Deployments/blob/main/core-portal/camino/dev.env#L1)

See test deploy [here](https://jenkins01.tacc.utexas.edu/view/WMA%20CEP/job/Core_Portal_Deploy/1085/console)

### Testing Steps
1. Change any setting in https://github.com/TACC/Core-Portal-Deployments/blob/main/core-portal/camino/dev.settings_custom.py
2. Via the jenkins task, perform a `deploy-core` on the `core-portal` `dev` environment
3. On the command line for the dev vm, confirm the settings have been picked up in the `portal_workers` and `portal_websockets` containers