### PR TITLE
task/FP-1797: update ciphers; bump send timeout

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -7,10 +7,10 @@ http {
     include /etc/nginx/mime.types;
     default_type    application/octet-stream;
     client_max_body_size 2G;
-    ssl_ciphers         EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH;
+    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_dhparam         /etc/ssl/dhparam.pem;
     ssl_prefer_server_ciphers on;
-    ssl_protocols       TLSv1.2;
+    ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_session_cache   shared:SSL:10m;
     ssl_session_timeout 10m;
 
@@ -47,7 +47,9 @@ http {
     }
 
     server {
-        listen 443 http2 ssl;
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+
         ssl_certificate     /etc/ssl/certs/portal.cer;
         ssl_certificate_key /etc/ssl/private/portal.key;
 
@@ -61,7 +63,7 @@ http {
 
         location / {
             uwsgi_read_timeout 60s;
-            uwsgi_send_timeout 60s;
+            uwsgi_send_timeout 600s;
             uwsgi_pass  portal_cms;
             include     /etc/nginx/uwsgi_params;
         }
@@ -76,14 +78,14 @@ http {
 
         location /core {
             uwsgi_read_timeout 60s;
-            uwsgi_send_timeout 60s;
+            uwsgi_send_timeout 600s;
             uwsgi_pass  portal_core;
             include     /etc/nginx/uwsgi_params;
         }
 
         location ~ ^/(auth|workbench|tickets|accounts|api|login|webhooks|googledrive-privacy-policy|public-data|search) {
             uwsgi_read_timeout 60s;
-            uwsgi_send_timeout 60s;
+            uwsgi_send_timeout 600s;
             uwsgi_pass  portal_core;
             include     /etc/nginx/uwsgi_params;
         }


### PR DESCRIPTION
- Per Andrew H, ISO scan returns "not compliant":

```
SCANS COMPLETED IN 3.915817 S
 ----------------------------- COMPLIANCE AGAINST MOZILLA TLS CONFIGURATION
 --------------------------------------------  Checking results against Mozilla's "intermediate" configuration. See https://ssl-config.mozilla.org/ for more details.  txapcd.org:443: FAILED - Not compliant.
    * ciphers: Cipher suites {'TLS_DHE_RSA_WITH_AES_256_CCM_8', 'TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA', 'TLS_DHE_RSA_WITH_AES_256_CCM', 'TLS_DHE_RSA_WITH_AES_256_CBC_SHA256', 'TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384', 'TLS_DHE_RSA_WITH_AES_256_CBC_SHA'} are supported, but should be rejected.
```

- Good idea to bump up uwsgi_send_timeout for large file uploads