### PR TITLE
Missing security headers we are getting dinged on in the portals

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -53,6 +53,21 @@ http {
         ssl_certificate     /etc/ssl/certs/portal.cer;
         ssl_certificate_key /etc/ssl/private/portal.key;
 
+        # Header requirements for HTTPS.
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;  #  Expires after 30 days.
+        add_header Content-Security-Policy "default-src 'self';" always;
+        add_header Referrer-Policy 'strict-origin' always;
+        add_header Feature-Policy "microphone self;camera self;geolocation self;notifications self;push self;sync-xhr self;speaker self;vibrate self;fullscreen self;payment self;midi self;magnetometer self;gyroscope self;" always;
+        set_cookie_flag secure;
+
+        # Omitting these for now but these headers will be required soon.
+        # add_header Cross-Origin-Resource-Policy cross-origin;
+        # add_header Cross-Origin-Embedder-Policy require-corp;
+        # add_header Cross-Origin-Opener-Policy: same-origin;
+
         location /media  {
             alias /var/www/portal/cms/media;
         }


### PR DESCRIPTION
This doesn't seem to deploy correctly yet, but it includes all the missing and soon-to-be-required security headers in the  https server block.
Might need to tweak the settings values but I matched the nginx and MSDN docs.
Need more eyes and further testing.


To test the deployed headers, use tis: https://securityheaders.com/?q=frontera-portal.tacc.utexas.edu&followRedirects=on

Or you can run: `curl portal_url -I` in the cli.

Refs:

- https://help.deepsecurity.trendmicro.com/20_0/on-premise/http-security-headers.html#:~:text=Security%20headers%20are%20directives%20used,Cross%2DSite%20Scripting%20or%20Clickjacking
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
- https://webdock.io/en/docs/how-guides/security-guides/how-to-configure-security-headers-in-nginx-and-apache
- https://www.getpagespeed.com/server-setup/nginx-security-headers-the-right-way
- https://serverfault.com/questions/965513/nginx-security-headers-within-location-block
