### PR TITLE
Bringing in the redirection code for domain based routing.

### DIFF
--- a/conf/compose/docker-compose.core.cms.yml
+++ b/conf/compose/docker-compose.core.cms.yml
@@ -6,6 +6,7 @@ services:
       service: nginx
     volumes:
       - ${CAMINO_HOME}/conf/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ${CAMINO_HOME}/conf/nginx/templates:/etc/nginx/templates
       - ${CAMINO_HOME}/conf/uwsgi/uwsgi_params:/etc/nginx/uwsgi_params
       - /etc/ssl/dhparam.pem:/etc/ssl/dhparam.pem
       - /var/www/portal/cms/static:/var/www/portal/cms/static
@@ -16,6 +17,8 @@ services:
       - 80:80
       - 443:443
     container_name: portal_nginx
+    environment:
+      - NGINX_SERVER_NAME=${NGINX_SERVER_NAME}
     logging:
       driver: syslog
       options:

--- a/conf/compose/docker-compose.core.docs.cms.yml
+++ b/conf/compose/docker-compose.core.docs.cms.yml
@@ -6,6 +6,7 @@ services:
       service: nginx
     volumes:
       - ${CAMINO_HOME}/conf/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ${CAMINO_HOME}/conf/nginx/templates:/etc/nginx/templates
       - ${CAMINO_HOME}/conf/uwsgi/uwsgi_params:/etc/nginx/uwsgi_params
       - /etc/ssl/dhparam.pem:/etc/ssl/dhparam.pem
       - /var/www/portal/cms/static:/var/www/portal/cms/static
@@ -16,6 +17,8 @@ services:
       - 80:80
       - 443:443
     container_name: portal_nginx
+    environment:
+      - NGINX_SERVER_NAME=${NGINX_SERVER_NAME}
     logging:
       driver: syslog
       options:

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -1,78 +1,40 @@
+user nginx;
+worker_processes auto;
+
+
 events {
-  worker_connections  4096;
+    worker_connections 1024;
 }
 
-http {
 
+http {
     include /etc/nginx/mime.types;
-    default_type    application/octet-stream;
-    client_max_body_size 2G;
-    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-    ssl_dhparam         /etc/ssl/dhparam.pem;
+    default_type application/octet-stream;
+
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_dhparam /etc/ssl/dhparam.pem;
     ssl_prefer_server_ciphers on;
-    ssl_protocols       TLSv1.2 TLSv1.3;
-    ssl_session_cache   shared:SSL:10m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;
+
+    charset utf-8;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    tcp_nopush on;
+
+    keepalive_timeout 65;
 
     gzip on;
     gzip_comp_level 6;
     gzip_vary on;
     gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/rss+xml text/javascript image/svg+xml application/vnd.ms-fontobject application/x-font-ttf font/opentype;
 
-    charset  utf-8;
-
-    # Extra slashes matter to Agave
-    merge_slashes off;
-
-    upstream portal_cms {
-        server portal_cms:8000;
-    }
-
-    ## Include any custom http directives
-    include /etc/nginx/conf.d/*.http.conf;
-
-    server {
-        listen 80 default_server;
-        listen [::]:80 default_server;
-        server_name _;
-        return 301 https://$host$request_uri;
-    }
-
-    server {
-        listen 443 ssl http2;
-        listen [::]:443 ssl http2;
-
-        ssl_certificate     /etc/ssl/certs/portal.cer;
-        ssl_certificate_key /etc/ssl/private/portal.key;
-
-        location /media  {
-            alias /var/www/portal/cms/media;
-        }
-
-        location /static {
-            alias /var/www/portal/cms/static;
-        }
-
-        location / {
-            uwsgi_read_timeout 60s;
-            uwsgi_send_timeout 600s;
-            uwsgi_pass  portal_cms;
-            include     /etc/nginx/uwsgi_params;
-        }
-
-        location /static/img/favicon.ico {
-            alias /var/www/portal/portal/static/favicon.ico;
-        }
-
-        location /favicon.ico {
-            alias /var/www/portal/portal/static/favicon.ico;
-        }
-
-        ## Include any custom location directives
-        include /etc/nginx/conf.d/*.location.conf;
-    }
-
-    ## Include any custom server directives
-    include /etc/nginx/conf.d/*.server.conf;
-
+    include /etc/nginx/conf.d/default.conf;
 }

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -1,0 +1,113 @@
+client_max_body_size 2G;
+
+# Extra slashes matter to Tapis
+merge_slashes off;
+
+upstream portal_cms {
+    server portal_cms:8000;
+    keepalive 2;
+}
+
+upstream portal_core {
+    server portal_django:6000;
+    keepalive 2;
+}
+
+upstream portal_ws {
+    server portal_websockets:9000;
+    keepalive 2;
+}
+
+## Include any custom http directives
+include /etc/nginx/conf.d/*.http.conf;
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name ${NGINX_SERVER_NAME};
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ${NGINX_SERVER_NAME};
+
+    if ($host != $server_name) {
+        rewrite ^(.*)$ https://$server_name$1;
+    }
+
+    ssl_certificate     /etc/ssl/certs/portal.cer;
+    ssl_certificate_key /etc/ssl/private/portal.key;
+
+    location /media  {
+        alias /var/www/portal/cms/media;
+    }
+
+    location /static {
+        alias /var/www/portal/cms/static;
+    }
+
+    location / {
+        uwsgi_read_timeout 60s;
+        uwsgi_send_timeout 600s;
+        uwsgi_pass  portal_cms;
+        include     /etc/nginx/uwsgi_params;
+    }
+
+    location /core/media  {
+        alias /var/www/portal/portal/media;
+    }
+
+    location /core/static {
+        alias /var/www/portal/portal/static;
+    }
+
+    location /core {
+        uwsgi_read_timeout 60s;
+        uwsgi_send_timeout 600s;
+        uwsgi_pass  portal_core;
+        include     /etc/nginx/uwsgi_params;
+    }
+
+    location ~ ^/(auth|workbench|tickets|accounts|api|login|webhooks|googledrive-privacy-policy|public-data|search) {
+        uwsgi_read_timeout 60s;
+        uwsgi_send_timeout 600s;
+        uwsgi_pass  portal_core;
+        include     /etc/nginx/uwsgi_params;
+    }
+
+    location /ws/ {
+        proxy_pass http://portal_ws;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $server_name;
+
+        proxy_read_timeout 600;
+    }
+
+    location /build {
+        alias /var/www/portal/portal/static;
+    }
+
+    location /static/img/favicon.ico {
+        alias /var/www/portal/portal/static/favicon.ico;
+    }
+
+    location /favicon.ico {
+        alias /var/www/portal/portal/static/favicon.ico;
+    }
+
+    ## Include any custom location directives
+    include /etc/nginx/conf.d/*.location.conf;
+}
+
+## Include any custom server directives
+include /etc/nginx/conf.d/*.server.conf;


### PR DESCRIPTION
Comparing the changes brought in from PR `task/FP-19547` (https://github.com/TACC/Camino/pull/24) to the CMS Only setup based on the `sciviscolor` branch.