### PR TITLE
Task WI-7: Add security headers in nginx conf

### DIFF
--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -40,16 +40,6 @@ server {
     ssl_certificate     /etc/ssl/certs/portal.cer;
     ssl_certificate_key /etc/ssl/private/portal.key;
 
-    # Do not add CSP restrictions until all issues are resolved.
-    # set $CSP_image  "img-src      'self' ; ";
-    # set $CSP_script "script-src   'self' *.bootstrapcdn.com cdnjs.cloudflare.com code.jquery.com *.googleapis.com *.google-analytics.com *.googletagmanager.com; ";
-    # set $CSP_style  "style-src    'self' *.bootstrapcdn.com cdnjs.cloudflare.com *.googleapis.com *.gstatic.com;";
-    # set $CSP_font   "font-src     'self' *.bootstrapcdn.com cdnjs.cloudflare.com *.googleapis.com *.gstatic.com;";
-    # set $CSP_frame  "frame-src    'self' ; ";
-    # set $CSP_object "object-src   'self' ; ";
-    # set $CSP        "default-src  'self' ; ${CSP_image} ${CSP_script} ${CSP_style} ${CSP_font} ${CSP_frame} ${CSP_object}";
-
-    # add_header Content-Security-Policy $CSP;
     add_header Permissions-Policy "autoplay=(), camera=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=()" always;
     add_header Referrer-Policy 'strict-origin' always;
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -40,6 +40,21 @@ server {
     ssl_certificate     /etc/ssl/certs/portal.cer;
     ssl_certificate_key /etc/ssl/private/portal.key;
 
+    # Do not add CSP restrictions until all issues are resolved.
+    # set $CSP_image  "img-src      'self' ; ";
+    # set $CSP_script "script-src   'self' *.bootstrapcdn.com cdnjs.cloudflare.com code.jquery.com *.googleapis.com *.google-analytics.com *.googletagmanager.com; ";
+    # set $CSP_style  "style-src    'self' *.bootstrapcdn.com cdnjs.cloudflare.com *.googleapis.com *.gstatic.com;";
+    # set $CSP_font   "font-src     'self' *.bootstrapcdn.com cdnjs.cloudflare.com *.googleapis.com *.gstatic.com;";
+    # set $CSP_frame  "frame-src    'self' ; ";
+    # set $CSP_object "object-src   'self' ; ";
+    # set $CSP        "default-src  'self' ; ${CSP_image} ${CSP_script} ${CSP_style} ${CSP_font} ${CSP_frame} ${CSP_object}";
+
+    # add_header Content-Security-Policy $CSP;
+    add_header Permissions-Policy "autoplay=(), camera=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=()" always;
+    add_header Referrer-Policy 'strict-origin' always;
+    add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+
     location /media  {
         alias /var/www/portal/cms/media;
     }


### PR DESCRIPTION
This is an adjustment to the original PR: https://github.com/TACC/Camino/pull/23

[Current violations](https://securityheaders.com/?q=frontera-portal.tacc.utexas.edu&followRedirects=on) as of today for security headers are: 

1. [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) Enforce https
2. Content Security Policy
3. [X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options#directives)
4. [Referrer Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#strict-origin_2)
5. Permissions Policy

Note: X-Frame-Options is already set as SAMEORIGIN

### Note:
CSP header fix will come into another PR in Core-Portal. The fix is not in nginx config, but in django using django-csp.

### Testing:
1) Deploy 3dem pprd with branch: task/WI-7-http-headers-security-fix. See jenkins build: [#2​88​7](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/2887/)
  Site load and login to workbench works.
2) Security headers site validation (without CSP, we are at A. With CSP, we get to A+).

<img width="1272" alt="Screenshot 2023-06-26 at 9 15 45 PM" src="https://github.com/TACC/Camino/assets/2568355/e0abcec9-f593-43d7-a879-c19f34048632">

<img width="1278" alt="Screenshot 2023-06-26 at 9 15 54 PM" src="https://github.com/TACC/Camino/assets/2568355/6e00c96b-b10c-4be5-a878-b4ef39eec358">

