### PR TITLE
Task WA-46: Add CSP Policy headers

### DIFF
--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -44,7 +44,7 @@ server {
     add_header Referrer-Policy 'strict-origin' always;
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header Content-Security-Policy "connect-src 'self' ws: wss: *.google-analytics.com *.googletagmanager.com *.tacc.utexas.edu" always;
+    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu" always;
 
     location /media  {
         alias /var/www/portal/cms/media;

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -44,6 +44,7 @@ server {
     add_header Referrer-Policy 'strict-origin' always;
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
+    add_header Content-Security-Policy "connect-src 'self' ws: wss: *.google-analytics.com *.googletagmanager.com *.tacc.utexas.edu" always;
 
     location /media  {
         alias /var/www/portal/cms/media;


### PR DESCRIPTION
### What's in this PR

nginx config uses content security policy. 

connect-src usage:
wss: [notifications in Core-Portal](https://github.com/TACC/Core-Portal/blob/main/client/src/redux/sagas/notifications.sagas.js#L7)
google-urls: based on recommendation from [Google Analytics 4 dev site](https://developers.google.com/tag-platform/tag-manager/csp#google_analytics_4_google_analytics)



### Testing
Validated the 3dem-staging (after [deployment](https://jenkins01.tacc.utexas.edu/view/WMA%20CEP/job/Core_Portal_Deploy/2921/) of this change) works well (authenticated and unauthenticated pages). There are no console error related to CSP.


[Security Headers
](https://securityheaders.com/?q=https%3A%2F%2F3dem-staging.tacc.utexas.edu%2F&followRedirects=on)
![Screenshot 2023-07-14 at 8 18 07 AM](https://github.com/TACC/Camino/assets/2568355/e2f1e52e-a185-4492-ae53-147d47b81995)

Jira: [WI-46](https://jira.tacc.utexas.edu/browse/WI-46)
