### PR TITLE
CMS container secrets deployment issue

### DIFF
--- a/conf/camino/docker-compose.override.sample.yml
+++ b/conf/camino/docker-compose.override.sample.yml
@@ -2,16 +2,16 @@ version: "3.8"
 services:
   nginx:
     volumes:
-      - /etc/ssl/sample.tacc.utexas.edu.cer:/etc/ssl/certs/portal.cer
-      - /etc/ssl/sample.tacc.utexas.edu.key:/etc/ssl/private/portal.key
+      - /etc/ssl/sample.tacc.utexas.edu.cer:/etc/ssl/certs/portal.cer:ro
+      - /etc/ssl/sample.tacc.utexas.edu.key:/etc/ssl/private/portal.key:ro
       - ./conf/camino/sample.server.conf:/etc/nginx/conf.d/sample.server.conf
       - ./conf/camino/sample.location.conf:/etc/nginx/conf.d/sample.location.conf
       - /var/www/portal/docs:/var/www/portal/docs
 
   websockets:
     volumes:
-      - /etc/ssl/sample.tacc.utexas.edu.cer:/etc/ssl/certs/portal.cer
-      - /etc/ssl/sample.tacc.utexas.edu.key:/etc/ssl/private/portal.key
+      - /etc/ssl/sample.tacc.utexas.edu.cer:/etc/ssl/certs/portal.cer:ro
+      - /etc/ssl/sample.tacc.utexas.edu.key:/etc/ssl/private/portal.key:ro
 
   docs:
     image: taccwma/portal-user-guide:latest

--- a/conf/compose/docker-compose.cms.yml
+++ b/conf/compose/docker-compose.cms.yml
@@ -3,7 +3,7 @@ services:
   cms:
     image: ${CMS_IMAGE}:${CMS_TAG}
     volumes:
-      - ${CAMINO_HOME}/conf/cms/secrets.py:/code/taccsite_cms/secrets.py
+      - ${CAMINO_HOME}/conf/cms/secrets.py:/code/taccsite_cms/secrets.py:ro
       - ${CAMINO_HOME}/conf/uwsgi/uwsgi_cms.ini:/code/uwsgi.ini
       - /var/www/portal/cms/static:/code/static
       - /var/www/portal/cms/media:/code/media

--- a/conf/compose/docker-compose.core.yml
+++ b/conf/compose/docker-compose.core.yml
@@ -3,7 +3,7 @@ services:
   core:
     image: ${PORTAL_IMAGE}:${PORTAL_TAG}
     volumes:
-      - ${CAMINO_HOME}/conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
+      - ${CAMINO_HOME}/conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py:ro
       - ${CAMINO_HOME}/conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
       - /var/www/portal/portal/media:/srv/www/portal/server/media
       - /var/www/portal/portal/static:/srv/www/portal/server/static

--- a/conf/compose/docker-compose.websockets.yml
+++ b/conf/compose/docker-compose.websockets.yml
@@ -4,7 +4,7 @@ services:
     image: ${PORTAL_IMAGE}:${PORTAL_TAG}
     command: 'daphne -b 0.0.0.0 -p 9000 -e ssl:443:privateKey=/etc/ssl/private/portal.key:certKey=/etc/ssl/certs/portal.cer --root-path=/srv/www/portal/server --access-log - --proxy-headers portal.asgi:application'
     volumes:
-      - ${CAMINO_HOME}/conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
+      - ${CAMINO_HOME}/conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py:ro
       - ${CAMINO_HOME}/conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
     container_name: portal_websockets
     logging:

--- a/conf/compose/docker-compose.workers.yml
+++ b/conf/compose/docker-compose.workers.yml
@@ -5,7 +5,7 @@ services:
       file: docker-compose.core.yml
       service: core
     volumes:
-      - ${CAMINO_HOME}/conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py
+      - ${CAMINO_HOME}/conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py:ro
       - ${CAMINO_HOME}/conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
     command: "celery -A portal worker -Q default,indexing,files,api,onboard --concurrency=10"
     container_name: portal_workers


### PR DESCRIPTION
Make all secrets files mounted as volumes in docker containers read only, using the :ro shorthand syntax, to prevent the unintentional generation of empty directories during initial setup.

JIRA Task: https://jira.tacc.utexas.edu/browse/WI-52


