### PR TITLE
Update Makefile to support Docker Compose v2.15.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ else
 override COMPOSE_OVERRIDE = -f ${CAMINO_HOME}/conf/camino/${COMPOSE_FILE}
 endif
 
-DOCKER_COMPOSE :=  docker-compose ${BASE_COMPOSE} ${COMPOSE_OVERRIDE} --env-file=$(ENV_FILE)
+DOCKER_COMPOSE :=  docker compose ${BASE_COMPOSE} ${COMPOSE_OVERRIDE} --env-file=$(ENV_FILE)
 
 .PHONY: deploy-core
 deploy-core:


### PR DESCRIPTION
Drops the docker-compose format for just `docker compose`, which breaks the Make command on step 44 during deployment.