### PR TITLE
fix: tup-677 css/django/vite interoperability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ deploy-cms:
 	$(DOCKER_COMPOSE) stop cms
 	$(DOCKER_COMPOSE) up -d
 	docker exec portal_cms python3 manage.py migrate
-	docker exec portal_cms python3 manage.py collectstatic --noinput --clear
+	docker exec portal_cms python3 manage.py collectstatic --noinput --clear --ignore assets/*/font*.css
 	$(DOCKER_COMPOSE) restart nginx
 
 .PHONY: deploy-all
@@ -47,7 +47,7 @@ deploy-all:
 	docker exec portal_django python3 manage.py migrate
 	docker exec portal_django python3 manage.py collectstatic --noinput --clear
 	docker exec portal_cms python3 manage.py migrate
-	docker exec portal_cms python3 manage.py collectstatic --noinput --clear
+	docker exec portal_cms python3 manage.py collectstatic --noinput --clear --ignore assets/*/font*.css
 	$(DOCKER_COMPOSE) restart nginx
 
 .PHONY: deploy-docs
@@ -94,4 +94,4 @@ migrate:
 
 .PHONY: collectstatic
 collectstatic:
-	$(DOCKER_COMPOSE) exec $(service) python3 manage.py collectstatic --noinput
+	$(DOCKER_COMPOSE) exec $(service) python3 manage.py collectstatic --noinput --ignore assets/*/font*.css


### PR DESCRIPTION
## Overview

Edit CMS `collectstatic` commands to ignore font stylesheets.

## Related

- [TUP-677](https://tacc-main.atlassian.net/browse/TUP-677)

<details><summary>Pull Requests</summary>

- https://github.com/TACC/tup-ui/pull/400 requires:
    - https://github.com/TACC/Core-Styles/pull/285
    - https://github.com/TACC/Core-CMS/pull/778 requires:
        - https://github.com/TACC/Core-Styles/pull/285
        - https://github.com/TACC/Core-CMS-Resources/pull/197 requires:
            - https://github.com/TACC/Camino/pull/44

</details>

## Changes

- **changed** `collectstatic` commands

## Testing

0. **Uncertain.** See https://github.com/TACC/tup-ui/pull/398.
1. Verify Frontera CMS can build with this workaround.
2. Test https://github.com/TACC/Core-CMS-Resources/pull/197.

## UI

See https://github.com/TACC/Core-CMS-Resources/pull/197.