### PR TITLE
NGINX header: add xss protection header

### DIFF
--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -45,6 +45,7 @@ server {
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu" always;
+    add_header X-XSS-Protection "1; mode=block" always;
 
     location /media  {
         alias /var/www/portal/cms/media;


### PR DESCRIPTION
### Details
This was suggested in WI-85 for APCD. Adding it for all portals is a good security measure.

### Work Item
[WI-85](https://tacc-main.atlassian.net/browse/WI-85)

### Testing
1. Did testing on [APCD QA ](https://apcd-qa.tacc.utexas.edu/)
2. Header
![Screenshot 2024-01-04 at 3 04 45 PM](https://github.com/TACC/Camino/assets/2568355/bab37826-fd75-4dc5-aa75-87ab7d5b27b9)
