### PR TITLE
Resolve errors in nginx regarding incorrect usage of http2 directive.

### DIFF
--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -29,8 +29,9 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
     server_name ${NGINX_SERVER_NAME};
 
     if ($host != $server_name) {


### PR DESCRIPTION
When deploying with the `latest` nginx image, this error occurs:


```
2024/01/12 18:46:02 [warn] 1#1: the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/conf.d/default.conf:32
nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/conf.d/default.conf:32
```

This PR eliminates it.