### PR TITLE
WP-553: Update celery command to start celery beat

### DIFF
--- a/conf/compose/docker-compose.workers.yml
+++ b/conf/compose/docker-compose.workers.yml
@@ -7,7 +7,8 @@ services:
     volumes:
       - ${CAMINO_HOME}/conf/portal/settings_secret.py:/srv/www/portal/server/portal/settings/settings_secret.py:ro
       - ${CAMINO_HOME}/conf/portal/settings_custom.py:/srv/www/portal/server/portal/settings/settings_custom.py
-    command: "celery -A portal worker -Q default,indexing,files,api,onboard --concurrency=10"
+    command: sh -c "celery -A portal beat -l info --pidfile= --schedule=/tmp/celerybeat-schedule & 
+             celery -A portal worker -Q default,indexing,files,api,onboard --concurrency=2"
     container_name: portal_workers
     logging:
       driver: syslog


### PR DESCRIPTION
## Overview
This is implementation of change from [PR 949 ](https://github.com/TACC/Core-Portal/pull/949) in Core Portal.

## Testing
This branch is deployed in dev cep [here](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/786).

And the feature is already tested in the Core Portal PR.