### PR TITLE
WI-193: provide service name to post deploy script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ deploy-service:
 	$(DOCKER_COMPOSE) stop $(service)
 	$(DOCKER_COMPOSE) up -d $(service)
 ifdef POST_DEPLOY_SCRIPT
-	chmod +x ${CAMINO_HOME}/conf/camino/${POST_DEPLOY_SCRIPT} && ${CAMINO_HOME}/conf/camino/${POST_DEPLOY_SCRIPT}
+	chmod +x ${CAMINO_HOME}/conf/camino/${POST_DEPLOY_SCRIPT} && ${CAMINO_HOME}/conf/camino/${POST_DEPLOY_SCRIPT} $(service)
 endif
 	$(DOCKER_COMPOSE) restart nginx
 
@@ -72,7 +72,7 @@ deploy-all:
 	$(DOCKER_COMPOSE) stop
 	$(DOCKER_COMPOSE) up -d
 ifdef POST_DEPLOY_SCRIPT
-	chmod +x ${CAMINO_HOME}/conf/camino/${POST_DEPLOY_SCRIPT} && ${CAMINO_HOME}/conf/camino/${POST_DEPLOY_SCRIPT}
+	chmod +x ${CAMINO_HOME}/conf/camino/${POST_DEPLOY_SCRIPT} && ${CAMINO_HOME}/conf/camino/${POST_DEPLOY_SCRIPT} all
 endif
 	$(DOCKER_COMPOSE) restart nginx
 

--- a/conf/scripts/post-deploy-core.sh
+++ b/conf/scripts/post-deploy-core.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-docker exec portal_django python manage.py migrate
-docker exec portal_django python manage.py collectstatic -c --noinput
-docker restart designsafe_django

--- a/conf/scripts/post-deploy.sh
+++ b/conf/scripts/post-deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+service=$1
+
+if [[ "$service" == *"core"* ]] || [[ "$service" == "all" ]]; then
+  docker exec portal_django python3 manage.py migrate
+  docker exec portal_django python3 manage.py collectstatic --noinput --clear
+fi
+
+if [[ "$service" == *"cms"* ]] || [[ "$service" == "all" ]]; then
+  docker exec portal_cms python3 manage.py migrate
+  docker exec portal_cms python3 manage.py collectstatic --noinput --clear
+fi


### PR DESCRIPTION
### Overview
post deploy script is different from core vs cms. The configs are same for core and cms (env file) for a portal.
if the post deploy script knows the service, it can handle different scenarios better.

corresponding config change for dev cep: [commit](https://github.com/TACC/Core-Portal-Deployments/commit/87eca81d798fa14ced50a11f3522f9147f2dfedd)

### Related
[WI-193](https://tacc-main.atlassian.net/browse/WI-193)


### Testing
core:
https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/default/937/console
cms:
https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/default/939/console

all:
https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/default/938/console