### PR TITLE
task/WI-223:  add additional docker compose override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,13 @@ else
 override COMPOSE =
 endif
 
-DOCKER_COMPOSE :=  ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(ENV_FILE)
+ifdef ADDITIONAL_COMPOSE_FILE
+override ADDITIONAL_COMPOSE = -f ${CAMINO_HOME}/conf/camino/${ADDITIONAL_COMPOSE_FILE}
+else
+override ADDITIONAL_COMPOSE =
+endif
+
+DOCKER_COMPOSE :=  ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} ${ADDITIONAL_COMPOSE} --env-file=$(ENV_FILE)
 
 .PHONY: deploy-docs
 deploy-docs:

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ endif
 
 # COMPOSE_FILE can be a single file or space-separated files
 ifdef COMPOSE_FILE
-COMPOSE := $(foreach file,$(COMPOSE_FILE),-f $(CAMINO_HOME)/conf/camino/$(file))
+override COMPOSE = $(foreach file,$(COMPOSE_FILE),-f $(CAMINO_HOME)/conf/camino/$(file))
 else
-COMPOSE :=
+override COMPOSE =
 endif
 
 DOCKER_COMPOSE :=  ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(ENV_FILE)

--- a/Makefile
+++ b/Makefile
@@ -17,19 +17,14 @@ else
 override BASE_COMPOSE =
 endif
 
+# COMPOSE_FILE can be a single file or space-separated files
 ifdef COMPOSE_FILE
-override COMPOSE = -f ${CAMINO_HOME}/conf/camino/${COMPOSE_FILE}
+COMPOSE := $(foreach file,$(COMPOSE_FILE),-f $(CAMINO_HOME)/conf/camino/$(file))
 else
-override COMPOSE =
+COMPOSE :=
 endif
 
-ifdef ADDITIONAL_COMPOSE_FILE
-override ADDITIONAL_COMPOSE = -f ${CAMINO_HOME}/conf/camino/${ADDITIONAL_COMPOSE_FILE}
-else
-override ADDITIONAL_COMPOSE =
-endif
-
-DOCKER_COMPOSE :=  ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} ${ADDITIONAL_COMPOSE} --env-file=$(ENV_FILE)
+DOCKER_COMPOSE :=  ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(ENV_FILE)
 
 .PHONY: deploy-docs
 deploy-docs:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Deploying with Jenkins:
 2. If required, update the service's image reference in the appropriate compose file as described above
 3. Go to [Frontera_Deployments](https://jenkins01.tacc.utexas.edu/view/Frontera%20Web/job/Frontera_Deploy/) in Jenkins and start a build, selecting environment and component/service
 
-A Makefile is included to faciliate manual deployment.
+A Makefile is included to facilitate manual deployment.
 
 Steps for manually deploying service:
 


### PR DESCRIPTION
## Overview

Allow for additional docker compose overrides.

Now, COMPOSE_FILE can be a single file:
```
COMPOSE_FILE=docker-compose.yml
```
or multiple files for additional overrides:
```
COMPOSE_FILE=docker-compose.yml docker-compose.experimental.yml
```


#### Notes

Ideally, this would be called `COMPOSE_FILES` instead of `COMPOSE_FILE` but I didn't change that.  I first thought of just having an additional variable like `ADDITONAL_COMPOSE_FILE` but then opted to extend `COMPOSE_FILE`

This is only used in one place **so if we don't want this, no problem**. If we didn't merge this, I would have a unique docker-compose.yml for that one deployed environment (geoapi experimental).

## Related

* [WI-233](https://tacc-main.atlassian.net/browse/WI-223)

## Testing

1. Deployed on Geoapi experimental.  See https://github.com/TACC/Core-Portal-Deployments/pull/54 and `geoapi-services/camino/experimental.env`


