### PR TITLE
task/WI-216: Add customizable robots.txt with anti-scraper default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ else
 override COMPOSE =
 endif
 
+ifdef ROBOTS_TXT
+override ROBOTS_TXT_PATH = ${CAMINO_HOME}/conf/camino/${ROBOTS_TXT}
+else
+override ROBOTS_TXT_PATH = ${CAMINO_HOME}/conf/nginx/robots.txt.default
+endif
+
 DOCKER_COMPOSE :=  ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(ENV_FILE)
 
 .PHONY: deploy-docs

--- a/conf/compose/docker-compose.nginx.yml
+++ b/conf/compose/docker-compose.nginx.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ${CAMINO_HOME}/conf/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ${CAMINO_HOME}/conf/nginx/templates/default.conf.template:/etc/nginx/templates/default.conf.template
-      - ${ROBOTS_TXT_PATH}:/var/www/robots.txt
+      - ${ROBOTS_TXT_PATH}:/var/www/robots.txt:ro
       - /etc/ssl/dhparam.pem:/etc/ssl/dhparam.pem:ro
     ports:
       - 80:80

--- a/conf/compose/docker-compose.nginx.yml
+++ b/conf/compose/docker-compose.nginx.yml
@@ -5,6 +5,7 @@ services:
     volumes:
       - ${CAMINO_HOME}/conf/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ${CAMINO_HOME}/conf/nginx/templates/default.conf.template:/etc/nginx/templates/default.conf.template
+      - ${ROBOTS_TXT_PATH}:/var/www/robots.txt
       - /etc/ssl/dhparam.pem:/etc/ssl/dhparam.pem:ro
     ports:
       - 80:80

--- a/conf/nginx/robots.txt.default
+++ b/conf/nginx/robots.txt.default
@@ -1,0 +1,41 @@
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: ClaudeBot/1.0
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: Omgili
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: ImagesiftBot 
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: *
+Disallow: /test

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -52,6 +52,10 @@ server {
         return 403;
     }
 
+    location /robots.txt {
+        alias /var/www/robots.txt;
+    }
+
     location /media  {
         alias /var/www/portal/cms/media;
     }

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -38,6 +38,10 @@ server {
     add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    location /robots.txt {
+        alias /var/www/robots.txt;
+    }
+
     location /media  {
         alias /var/www/portal/cms/media;
     }


### PR DESCRIPTION
Adds the ability for portals to specify a custom `robots.txt` file. The default is a safeguard against LLM scraping. To customize, add a `robots.txt` in the portal's directory in core-portal-deployments and set `ROBOTS_TXT=robots.txt` to the environment file.