### PR TITLE
Quick: Fix docker compose environment config for robots.txt path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,7 @@ else
 override COMPOSE =
 endif
 
-ifdef ROBOTS_TXT
-override ROBOTS_TXT_PATH = ${CAMINO_HOME}/conf/camino/${ROBOTS_TXT}
-else
-override ROBOTS_TXT_PATH = ${CAMINO_HOME}/conf/nginx/robots.txt.default
-endif
-
-DOCKER_COMPOSE := ROBOTS_TXT_PATH=${ROBOTS_TXT_PATH} ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(ENV_FILE)
+DOCKER_COMPOSE := ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(ENV_FILE)
 
 .PHONY: deploy-docs
 deploy-docs:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ else
 override ROBOTS_TXT_PATH = ${CAMINO_HOME}/conf/nginx/robots.txt.default
 endif
 
-DOCKER_COMPOSE :=  ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(ENV_FILE)
+DOCKER_COMPOSE := ROBOTS_TXT_PATH=${ROBOTS_TXT_PATH} ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(ENV_FILE)
 
 .PHONY: deploy-docs
 deploy-docs:

--- a/conf/compose/docker-compose.nginx.yml
+++ b/conf/compose/docker-compose.nginx.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ${CAMINO_HOME}/conf/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ${CAMINO_HOME}/conf/nginx/templates/default.conf.template:/etc/nginx/templates/default.conf.template
-      - ${ROBOTS_TXT_PATH}:/var/www/robots.txt:ro
+      - ${CAMINO_HOME}/conf/nginx/robots.txt.default:/var/www/robots.txt:ro
       - /etc/ssl/dhparam.pem:/etc/ssl/dhparam.pem:ro
     ports:
       - 80:80


### PR DESCRIPTION
Ensure that the ROBOTS_TXT_PATH env variable is passed to docker compose.