### PR TITLE
WI-97: Pin versions of base images in all camino docker templates

### DIFF
--- a/conf/compose/docker-compose.memcached.yml
+++ b/conf/compose/docker-compose.memcached.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   memcached:
-    image: memcached:1.6.32
+    image: memcached:1.6-bookworm
     command: ["memcached"]
     container_name: portal_memcached
     restart: always

--- a/conf/compose/docker-compose.memcached.yml
+++ b/conf/compose/docker-compose.memcached.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   memcached:
-    image: memcached:latest
+    image: memcached:1.6.32
     command: ["memcached"]
     container_name: portal_memcached
     restart: always

--- a/conf/compose/docker-compose.nginx.yml
+++ b/conf/compose/docker-compose.nginx.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   nginx:
-    image: nginx:1.27.3
+    image: nginx:stable
     volumes:
       - ${CAMINO_HOME}/conf/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ${CAMINO_HOME}/conf/nginx/templates/default.conf.template:/etc/nginx/templates/default.conf.template

--- a/conf/compose/docker-compose.nginx.yml
+++ b/conf/compose/docker-compose.nginx.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   nginx:
-    image: nginx
+    image: nginx:1.27.3
     volumes:
       - ${CAMINO_HOME}/conf/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ${CAMINO_HOME}/conf/nginx/templates/default.conf.template:/etc/nginx/templates/default.conf.template


### PR DESCRIPTION
## Overview
Need to ping images like nginx to avoid getting latest with breaking changes.
memcached does not have stable version.
nginx has a stable version.

## Related
[WI-97](https://tacc-main.atlassian.net/browse/WI-97)

## Changes
nginx : 1.27.3
memcached: 1.6.32
Rest are already pinned.

## Testing

Deployed to dev.cep.
```
docker ps --no-trunc
CONTAINER ID                                                       IMAGE                        COMMAND                                                                                                                                                                                                     CREATED             STATUS          PORTS                                                                      NAMES
7f5c2520008796957d97a8278bf301550b55246d048f14db34578d5fec230e9b   nginx:stable                 "/docker-entrypoint.sh nginx -g 'daemon off;'"                                                                                                                                                              32 seconds ago      Up 5 seconds    0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp   portal_nginx
d8a2a3338cf8a36049672fb3134b4573ba2d37802f17169ad04c5e4ff3a595e6   memcached:1.6.32             "docker-entrypoint.sh memcached"
```