### PR TITLE
WI-202 FIX: Syntax fixes for letsencrypt script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ else
 override COMPOSE =
 endif
 
-DOCKER_COMPOSE := ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(pwd)/$(ENV_FILE)
+DOCKER_COMPOSE := ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(shell pwd)/$(ENV_FILE)
 
 # This command uses an Alpine linux image to run a script to add a post-renew hook to letsencrypt 
 PLACE_RENEWAL_HOOK := docker run -e DOCKER_COMPOSE="${DOCKER_COMPOSE}" -v /etc/letsencrypt:/etc/letsencrypt -v ${CAMINO_HOME}/conf/scripts/post-renew.sh:/opt/post-renew.sh alpine:3 /bin/sh -c "chmod +x /opt/post-renew.sh && /opt/post-renew.sh"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 DOCKER_COMPOSE := ${COMPOSE_COMMAND} ${BASE_COMPOSE} ${COMPOSE} --env-file=$(pwd)/$(ENV_FILE)
 
 # This command uses an Alpine linux image to run a script to add a post-renew hook to letsencrypt 
-PLACE_RENEWAL_HOOK := docker run -e DOCKER_COMPOSE=${DOCKER_COMPOSE} -v /etc/letsencrypt:/etc/letsencrypt -v ${CAMINO_HOME}/conf/scripts/post-renew.sh:/opt-post-renew.sh alpine:3 /bin/sh -c "chmod +x /opt/post-renew.sh && /opt/post-renew.sh"
+PLACE_RENEWAL_HOOK := docker run -e DOCKER_COMPOSE="${DOCKER_COMPOSE}" -v /etc/letsencrypt:/etc/letsencrypt -v ${CAMINO_HOME}/conf/scripts/post-renew.sh:/opt/post-renew.sh alpine:3 /bin/sh -c "chmod +x /opt/post-renew.sh && /opt/post-renew.sh"
 
 .PHONY: deploy-docs
 deploy-docs:

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ endif
 migrate:
 	$(DOCKER_COMPOSE) exec $(service) python3 manage.py migrate
 
+.PHONY: place-renewal-hook
+place-renewal-hook:
+	$(PLACE_RENEWAL_HOOK)
+
 .PHONY: collectstatic
 collectstatic:
 	$(DOCKER_COMPOSE) exec $(service) python3 manage.py collectstatic --noinput


### PR DESCRIPTION
- Place quotes around `DOCKER_COMPOSE` env variable so that the command isn't read as an image name
- fix `/opt/post-renew.sh` path