### PR TITLE
Task: Addressing Information Level Results from BURP Scanner

### DIFF
--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -41,12 +41,20 @@ server {
     ssl_certificate     /etc/ssl/certs/portal.cer;
     ssl_certificate_key /etc/ssl/private/portal.key;
 
+    set $cspNonce $ssl_session_id
+
+    sub_filter_once off;
+    sub_filter_types *;
+    sub_filter CSP_NONCE $cspNonce;
+
     add_header Permissions-Policy "autoplay=(), camera=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=()" always;
     add_header Referrer-Policy 'strict-origin' always;
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu" always;
+    add_header Content-Security-Policy "form-action 'none'; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu" 'nonce-$cspNonce' always;
     add_header X-XSS-Protection "1; mode=block" always;
+    add_header Cache-control no-store;
+    add_header Pragma no-cache;
 
     if ($http_user_agent ~* "claudebot|anthropic") {
         return 403;

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -53,8 +53,9 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Content-Security-Policy "form-action 'none'; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu" 'nonce-$cspNonce' always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Cache-control no-store;
-    add_header Pragma no-cache;
+    add_header Cache-control "no-store";
+    add_header Pragma "no-cache";
+    add_header X-Frame-Options "SAMEORIGIN";
 
     if ($http_user_agent ~* "claudebot|anthropic") {
         return 403;


### PR DESCRIPTION
Added various headers to attempt to address some of the information level results from recent BURP scanner for CIPP. Includes a change that may impact Core-CMS (added NONCE for Google scripts), which has its own pull request. 