### PR TITLE
task/WI-367: add post-deploy hook to delete user sessions after deployment

### DIFF
--- a/conf/scripts/post-deploy.sh
+++ b/conf/scripts/post-deploy.sh
@@ -26,7 +26,7 @@ count = stale_tokens.delete()[0]
 print(f'Deleted {count} Tapis tokens for users without active sessions')
 "
 
-  # Delete all sessions to force users to log out after deployment
+  # Delete all expired sessions
   docker exec portal_django python3 manage.py clearsessions
 fi
 

--- a/conf/scripts/post-deploy.sh
+++ b/conf/scripts/post-deploy.sh
@@ -7,6 +7,9 @@ if [[ -n "$(docker ps -q -f name=^/portal_django$)" && ("$service" == *"core"* |
   docker exec portal_django python3 manage.py migrate
   docker exec portal_django python3 manage.py collectstatic --noinput --clear
 
+  # Delete all expired sessions
+  docker exec portal_django python3 manage.py clearsessions
+
   # Delete Tapis tokens for users who do not have an active session
   docker exec portal_django python3 manage.py shell -c "
 from django.contrib.sessions.models import Session
@@ -25,9 +28,6 @@ for token in stale_tokens:
 count = stale_tokens.delete()[0]
 print(f'Deleted {count} Tapis tokens for users without active sessions')
 "
-
-  # Delete all expired sessions
-  docker exec portal_django python3 manage.py clearsessions
 fi
 
 if [[ -n "$(docker ps -q -f name=^/portal_cms$)" && ("$service" == *"cms"* || "$service" == "all") ]]; then

--- a/conf/scripts/post-deploy.sh
+++ b/conf/scripts/post-deploy.sh
@@ -24,7 +24,7 @@ for session in Session.objects.all():
 
 stale_tokens = TapisOAuthToken.objects.exclude(user_id__in=users_with_active_sessions)
 for token in stale_tokens:
-    print(f'Removing stale token for user: {token.user.username}')
+    print(f'Removing Tapis token for inactive user: {token.user.username}')
 count = stale_tokens.delete()[0]
 print(f'Deleted {count} Tapis tokens for users without active sessions')
 "

--- a/conf/scripts/post-deploy.sh
+++ b/conf/scripts/post-deploy.sh
@@ -8,7 +8,27 @@ if [[ -n "$(docker ps -q -f name=^/portal_django$)" && ("$service" == *"core"* |
   docker exec portal_django python3 manage.py collectstatic --noinput --clear
 
   # Delete all sessions to force users to log out after deployment
+  # (KNOWN TODO: delete just expired sessions)
   docker exec portal_django python3 manage.py shell -c "from django.contrib.sessions.models import Session; Session.objects.all().delete()"
+
+  # Delete Tapis tokens for users who do not have an active session
+  docker exec portal_django python3 manage.py shell -c "
+from django.contrib.sessions.models import Session
+from portal.apps.auth.models import TapisOAuthToken
+
+users_with_active_sessions = set()
+for session in Session.objects.all():
+    data = session.get_decoded()
+    uid = data.get('_auth_user_id')
+    if uid:
+        users_with_active_sessions.add(int(uid))
+
+stale_tokens = TapisOAuthToken.objects.exclude(user_id__in=users_with_active_sessions)
+for token in stale_tokens:
+    print(f'Removing stale token for user: {token.user.username}')
+count = stale_tokens.delete()[0]
+print(f'Deleted {count} Tapis tokens for users without active sessions')
+"
 fi
 
 if [[ -n "$(docker ps -q -f name=^/portal_cms$)" && ("$service" == *"cms"* || "$service" == "all") ]]; then

--- a/conf/scripts/post-deploy.sh
+++ b/conf/scripts/post-deploy.sh
@@ -7,10 +7,6 @@ if [[ -n "$(docker ps -q -f name=^/portal_django$)" && ("$service" == *"core"* |
   docker exec portal_django python3 manage.py migrate
   docker exec portal_django python3 manage.py collectstatic --noinput --clear
 
-  # Delete all sessions to force users to log out after deployment
-  # (KNOWN TODO: delete just expired sessions)
-  docker exec portal_django python3 manage.py shell -c "from django.contrib.sessions.models import Session; Session.objects.all().delete()"
-
   # Delete Tapis tokens for users who do not have an active session
   docker exec portal_django python3 manage.py shell -c "
 from django.contrib.sessions.models import Session
@@ -29,6 +25,9 @@ for token in stale_tokens:
 count = stale_tokens.delete()[0]
 print(f'Deleted {count} Tapis tokens for users without active sessions')
 "
+
+  # Delete all sessions to force users to log out after deployment
+  docker exec portal_django python3 manage.py clearsessions
 fi
 
 if [[ -n "$(docker ps -q -f name=^/portal_cms$)" && ("$service" == *"cms"* || "$service" == "all") ]]; then

--- a/conf/scripts/post-deploy.sh
+++ b/conf/scripts/post-deploy.sh
@@ -37,5 +37,5 @@ if [[ -n "$(docker ps -q -f name=^/portal_cms$)" && ("$service" == *"cms"* || "$
   docker exec portal_cms python3 manage.py collectstatic --noinput --clear
 
   # Delete all expired sessions
-  docker exec portal_django python3 manage.py clearsessions
+  docker exec portal_cms python3 manage.py clearsessions
 fi

--- a/conf/scripts/post-deploy.sh
+++ b/conf/scripts/post-deploy.sh
@@ -36,6 +36,6 @@ if [[ -n "$(docker ps -q -f name=^/portal_cms$)" && ("$service" == *"cms"* || "$
   docker exec portal_cms python3 manage.py migrate
   docker exec portal_cms python3 manage.py collectstatic --noinput --clear
 
-  # Delete all sessions to force users to log out after deployment
-  docker exec portal_cms python3 manage.py shell -c "from django.contrib.sessions.models import Session; Session.objects.all().delete()"
+  # Delete all expired sessions
+  docker exec portal_django python3 manage.py clearsessions
 fi

--- a/conf/scripts/post-deploy.sh
+++ b/conf/scripts/post-deploy.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
 service=$1
 
-if [[ "$service" == *"core"* ]] || [[ "$service" == "all" ]]; then
+if [[ -n "$(docker ps -q -f name=^/portal_django$)" && ("$service" == *"core"* || "$service" == "all") ]]; then
+  echo "Running post-deploy script for portal_django..."
+
   docker exec portal_django python3 manage.py migrate
   docker exec portal_django python3 manage.py collectstatic --noinput --clear
+
+  # Delete all sessions to force users to log out after deployment
+  docker exec portal_django python3 manage.py shell -c "from django.contrib.sessions.models import Session; Session.objects.all().delete()"
 fi
 
-if [[ "$service" == *"cms"* ]] || [[ "$service" == "all" ]]; then
+if [[ -n "$(docker ps -q -f name=^/portal_cms$)" && ("$service" == *"cms"* || "$service" == "all") ]]; then
+  echo "Running post-deploy script for portal_cms..."
+
   docker exec portal_cms python3 manage.py migrate
   docker exec portal_cms python3 manage.py collectstatic --noinput --clear
+
+  # Delete all sessions to force users to log out after deployment
+  docker exec portal_cms python3 manage.py shell -c "from django.contrib.sessions.models import Session; Session.objects.all().delete()"
 fi


### PR DESCRIPTION
You can test this locally: 
1. Have core portal running
2. Login
3. Run this script with and without declaring `service="all"`, and with and without the containers running to verify logic

```
if [[ -n "$(docker ps -q -f name=^/core_portal_django$)" && ("$service" == *"core"* || "$service" == "all") ]]; then
  echo "Running post-deploy script for core_portal_django..."

  docker exec core_portal_django python3 manage.py shell -c "from django.contrib.sessions.models import Session; Session.objects.all().delete()"
fi
```