### PR TITLE
feat: csp_connect_extra in default nginx template

### DIFF
--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -53,7 +53,14 @@ server {
     add_header Referrer-Policy 'strict-origin' always;
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header Content-Security-Policy "form-action 'self'; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com 'nonce-$cspNonce'" always;
+
+    # CSP 'connect-src':
+    #   Shared domains (e.g. google analytics) are listed below. Service-specific domains
+    # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
+    # deployment in Core-Portal-Deployments).
+    #
+    add_header Content-Security-Policy "form-action 'self'; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra} 'nonce-$cspNonce'" always;
+
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Cache-control "no-store";
     add_header Pragma "no-cache";


### PR DESCRIPTION
## Overview

Allow more CSP entries via `$csp_connect_extra` in default Nginx config.

## Related

- builds upon #68
- required by https://github.com/TACC/Core-Portal-Deployments/pull/157

## Changes

Into default Nginx config:

- **add** `${csp_connect_extra}`
- **doc** `csp_connect_extra`

## Testing / UI

See https://github.com/TACC/Core-Portal-Deployments/pull/157.