### PR TITLE
feat: csp_connect_extra in sad.cms nginx template

### DIFF
--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -44,6 +44,7 @@ server {
     # deployment in Core-Portal-Deployments).
     #
     add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu" ${csp_connect_extra} always;
+
     add_header X-XSS-Protection "1; mode=block" always;
 
     location /robots.txt {

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -37,7 +37,13 @@ server {
     add_header Referrer-Policy 'strict-origin' always;
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu" always;
+
+    # CSP 'connect-src':
+    #   Shared domains (e.g. google analytics) are listed below. Service-specific domains
+    # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
+    # deployment in Core-Portal-Deployments).
+    #
+    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu" ${csp_connect_extra} always;
     add_header X-XSS-Protection "1; mode=block" always;
 
     location /robots.txt {

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -43,7 +43,7 @@ server {
     # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
     # deployment in Core-Portal-Deployments).
     #
-    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu" ${csp_connect_extra} always;
+    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu ${csp_connect_extra}" always;
 
     add_header X-XSS-Protection "1; mode=block" always;
 


### PR DESCRIPTION
## Overview

Allow more CSP entries via `$csp_connect_extra` in "Sad CMS" Nginx config.

## Related

- builds upon #68
- similar to #70
- required by https://github.com/TACC/Core-Portal-Deployments/pull/158

## Changes

Into `sad.cms` Nginx config:

- **add** `${csp_connect_extra}`
- **doc** `csp_connect_extra`

## Testing & UI

See https://github.com/TACC/Core-Portal-Deployments/pull/158.