### PR TITLE
feat: sad.cms Nginx template, enhance CSP headers

### DIFF
--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -37,13 +37,19 @@ server {
     add_header Referrer-Policy 'strict-origin' always;
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
+    # X-Frame-Options: SAMEORIGIN for legacy browser fallback only.
+    # Modern browsers use frame-ancestors in CSP below, which supports wildcards
+    # and allows iframing from *.tacc.utexas.edu
+    add_header X-Frame-Options "SAMEORIGIN" always;
 
     # CSP 'connect-src':
     #   Shared domains (e.g. google analytics) are listed below. Service-specific domains
     # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
     # deployment in Core-Portal-Deployments).
     #
-    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu ${csp_connect_extra}" always;
+    # CSP 'frame-ancestors':
+    #   Allows services to be iframed into TACC portals (e.g. Imageinf iframed into CEP).
+    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu ${csp_connect_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
 
     add_header X-XSS-Protection "1; mode=block" always;
 


### PR DESCRIPTION
## Changes

- Added `X-Frame-Options` header for legacy browser support.
- Updated `Content-Security-Policy` to include `frame-ancestors` and `form-action` directives, allowing iFraming from TACC portals and enhancing form security.

## Related

- to fix security scan for site using https://github.com/TACC/Core-Portal-Deployments/pull/146

## Testing & UI

> [!NOTE]
> Was deployed to:
> - `pprd.ecep`
> - `prod.ecep`
> - `pprd.wtcs`
> - ~~`prod.wtcs`~~ ([WI-426](https://tacc-main.atlassian.net/browse/WI-426))
> - ~~`pprd.sciviscolor`~~ ([WI-427](https://tacc-main.atlassian.net/browse/WI-427))
> - `prod.sciviscolor`

1. [ ] Does [NSO rescan](https://tickets.tacc.utexas.edu/Ticket/Display.html?id=40160) succeed?
2. [x] Verify new CSP shows up.
    <img width="900" height="475" alt="wtcs csp" src="https://github.com/user-attachments/assets/dbded3de-5062-48b1-9254-d83b0b3c71f3" />
3. [x] Verify `X-Frame-Options`/`frame-ancestors` works on [CTRN Web iFrames](https://ctrn-web-2026.tacc.utexas.edu/about/by-the-numbers/).[^3]
    <sup>No problem on modern browsers, because `*.tacc.utexas.edu` allows `ctrn-portal.tacc.utexas.edu`.</sup>

[^3]: [CTRN-Web `/about/by-the-numbers/`](https://ctrn-web-2026.tacc.utexas.edu/about/by-the-numbers/) uses frame from another server, CTRN-portal.