### PR TITLE
task/WG-661: support hazmapper in newest camino

### DIFF
--- a/conf/nginx/templates/csp-map.http.conf
+++ b/conf/nginx/templates/csp-map.http.conf
@@ -1,4 +1,4 @@
-# Default CSP "extra" maps for service.conf.template (e.g. connect-src, style-src, script-src).
+# Default CSP "extra" maps for service.conf.template (e.g. connect-src, style-src, script-src, img-src).
 #    Override in Core-Portal-Deployments for service-specific domains.
 map $host $csp_connect_extra {
     default "";
@@ -10,5 +10,8 @@ map $host $csp_script_extra {
     default "";
 }
 map $host $csp_font_extra {
+    default "";
+}
+map $host $csp_img_extra {
     default "";
 }

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -64,7 +64,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Cache-control "no-store";
     add_header Pragma "no-cache";
-    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Frame-Options "SAMEORIGIN" always;
 
     if ($http_user_agent ~* "claudebot|anthropic") {
         return 403;

--- a/conf/nginx/templates/service.conf.template
+++ b/conf/nginx/templates/service.conf.template
@@ -26,7 +26,7 @@ server {
     ## Don't overwrite server-level headers if a header is set at the location level.
     add_header_inherit merge;
     add_header Permissions-Policy "autoplay=(), camera=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=()" always;
-    add_header Referrer-Policy 'strict-origin' always;
+    add_header Referrer-Policy 'strict-origin-when-cross-origin' always;
     add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
     # X-Frame-Options: SAMEORIGIN for legacy browser fallback only.

--- a/conf/nginx/templates/service.conf.template
+++ b/conf/nginx/templates/service.conf.template
@@ -34,15 +34,15 @@ server {
     # and allows iframing from *.tacc.utexas.edu
     add_header X-Frame-Options "SAMEORIGIN" always;
 
-    # CSP 'connect-src' / 'style-src' / 'script-src' / 'font-src':
+    # CSP 'connect-src' / 'style-src' / 'script-src' / 'font-src' / 'img-src':
     #   Shared domains (e.g. google analytics) are listed below. Service-specific domains
     #   are appended via $csp_connect_extra / $csp_style_extra / $csp_script_extra /
-    #   $csp_font_extra (csp-map.http.conf), overridable per
+    #   $csp_font_extra / $csp_img_extra (csp-map.http.conf), overridable per
     #   deployment in Core-Portal-Deployments.
     #
     # CSP 'frame-ancestors':
     #   Allows services to be iframed into TACC portals (e.g. Imageinf iframed into CEP).
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' ${csp_script_extra}; style-src 'self' 'unsafe-inline' ${csp_style_extra}; font-src 'self' ${csp_font_extra}; img-src 'self' blob:; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io ${csp_connect_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' ${csp_script_extra}; style-src 'self' 'unsafe-inline' ${csp_style_extra}; font-src 'self' ${csp_font_extra}; img-src 'self' blob: ${csp_img_extra} ; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io ${csp_connect_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
     ## Include any custom location directives


### PR DESCRIPTION
## Overview 

Changes the server-level `Referrer-Policy` from `strict-origin` to
`strict-origin-when-cross-origin`.

Also , adds a missing `always` to X-Frame-Options

## Notes

Testing on hazmapper.tacc with a branch in Core-Portal-Deployments