### PR TITLE
task/WG-473: add frame-src directive to service template

### DIFF
--- a/conf/nginx/templates/csp-map.http.conf
+++ b/conf/nginx/templates/csp-map.http.conf
@@ -1,4 +1,4 @@
-# Default CSP "extra" maps for service.conf.template (e.g. connect-src, style-src, script-src, img-src).
+# Default CSP "extra" maps for service.conf.template (e.g. connect-src, style-src, script-src, img-src, frame-extra).
 #    Override in Core-Portal-Deployments for service-specific domains.
 map $host $csp_connect_extra {
     default "";
@@ -13,5 +13,8 @@ map $host $csp_font_extra {
     default "";
 }
 map $host $csp_img_extra {
+    default "";
+}
+map $host $csp_frame_extra {
     default "";
 }

--- a/conf/nginx/templates/service.conf.template
+++ b/conf/nginx/templates/service.conf.template
@@ -34,7 +34,7 @@ server {
     # and allows iframing from *.tacc.utexas.edu
     add_header X-Frame-Options "SAMEORIGIN" always;
 
-    # CSP 'connect-src' / 'style-src' / 'script-src' / 'font-src' / 'img-src':
+    # CSP 'connect-src' / 'style-src' / 'script-src' / 'font-src' / 'img-src'/ 'frame-src'':
     #   Shared domains (e.g. google analytics) are listed below. Service-specific domains
     #   are appended via $csp_connect_extra / $csp_style_extra / $csp_script_extra /
     #   $csp_font_extra / $csp_img_extra (csp-map.http.conf), overridable per
@@ -42,7 +42,7 @@ server {
     #
     # CSP 'frame-ancestors':
     #   Allows services to be iframed into TACC portals (e.g. Imageinf iframed into CEP).
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' ${csp_script_extra}; style-src 'self' 'unsafe-inline' ${csp_style_extra}; font-src 'self' ${csp_font_extra}; img-src 'self' blob: ${csp_img_extra} ; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io ${csp_connect_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' ${csp_script_extra}; style-src 'self' 'unsafe-inline' ${csp_style_extra}; font-src 'self' ${csp_font_extra}; img-src 'self' blob: ${csp_img_extra}; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io ${csp_connect_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
     ## Include any custom location directives


### PR DESCRIPTION
# Overview

For hazmapper, we need to add frame-src directive needed in Camino's service.conf.template. Hazmapper embeds Mapillary in an iframe and being blocked currently.

# Related Jira

https://tacc-main.atlassian.net/browse/WI-473