### PR TITLE
task/WI-477: Move default portal headers to snippet; optimize location routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ conf/camino/*
 rabbitmq.env
 conf/portal/*
 !conf/portal/*example.*
+.vscode/

--- a/conf/compose/docker-compose.nginx.yml
+++ b/conf/compose/docker-compose.nginx.yml
@@ -5,6 +5,7 @@ services:
     volumes:
       - ${CAMINO_HOME}/conf/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ${CAMINO_HOME}/conf/nginx/templates/default.conf.template:/etc/nginx/templates/default.conf.template
+      - ${CAMINO_HOME}/conf/nginx/snippets/cep-headers.conf:/etc/nginx/snippets/cep-headers.conf:ro
       # Per-service CSP domains used by service.conf.template
       - ${CAMINO_HOME}/conf/nginx/templates/csp-map.http.conf:/etc/nginx/conf.d/csp-map.http.conf:ro
       - ${CAMINO_HOME}/conf/nginx/robots.txt.default:/var/www/robots.txt:ro

--- a/conf/nginx/snippets/cep-headers.conf
+++ b/conf/nginx/snippets/cep-headers.conf
@@ -1,0 +1,28 @@
+set $cspNonce $ssl_session_id;
+
+sub_filter_once off;
+sub_filter_types *;
+sub_filter CSP_NONCE $cspNonce;
+
+## Don't overwrite server-level headers if a header is set at the location level.
+add_header_inherit merge;
+add_header Permissions-Policy "autoplay=(), camera=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=()" always;
+add_header Referrer-Policy 'strict-origin' always;
+add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
+add_header X-Content-Type-Options "nosniff" always;
+
+# CSP 'connect-src':
+#   Shared domains (e.g. google analytics) are listed below. Service-specific domains
+# are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
+# deployment in Core-Portal-Deployments).
+#
+add_header Content-Security-Policy "form-action 'self'; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra} 'nonce-$cspNonce'" always;
+
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Cache-control "no-store";
+add_header Pragma "no-cache";
+add_header X-Frame-Options "SAMEORIGIN" always;
+
+if ($http_user_agent ~* "claudebot|anthropic") {
+    return 403;
+}

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -41,70 +41,49 @@ server {
     ssl_certificate     /etc/ssl/certs/portal.cer;
     ssl_certificate_key /etc/ssl/private/portal.key;
 
-    set $cspNonce $ssl_session_id;
+    # Include default security headers
+    include /etc/nginx/snippets/cep-headers.conf;
 
-    sub_filter_once off;
-    sub_filter_types *;
-    sub_filter CSP_NONCE $cspNonce;
-
-    ## Don't overwrite server-level headers if a header is set at the location level.
-    add_header_inherit merge;
-    add_header Permissions-Policy "autoplay=(), camera=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=()" always;
-    add_header Referrer-Policy 'strict-origin' always;
-    add_header Strict-Transport-Security "max-age=2592000; includeSubDomains" always;
-    add_header X-Content-Type-Options "nosniff" always;
-
-    # CSP 'connect-src':
-    #   Shared domains (e.g. google analytics) are listed below. Service-specific domains
-    # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
-    # deployment in Core-Portal-Deployments).
-    #
-    add_header Content-Security-Policy "form-action 'self'; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra} 'nonce-$cspNonce'" always;
-
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Cache-control "no-store";
-    add_header Pragma "no-cache";
-    add_header X-Frame-Options "SAMEORIGIN" always;
-
-    if ($http_user_agent ~* "claudebot|anthropic") {
-        return 403;
-    }
-
-    location /robots.txt {
+    location = /robots.txt {
         alias /var/www/robots.txt;
     }
 
-    location /media  {
-        alias /var/www/portal/cms/media;
+    location = /favicon.ico {
+        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
     }
 
-    location /static {
-        alias /var/www/portal/cms/static;
+    location = /static/img/favicon.ico {
+        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
     }
 
-    location / {
-        uwsgi_read_timeout 60s;
-        uwsgi_send_timeout 600s;
-        uwsgi_pass  portal_cms;
-        include     /etc/nginx/uwsgi_params;
+    location ^~ /core/media/  {
+        alias /var/www/portal/portal/media/;
     }
 
-    location /core/media  {
-        alias /var/www/portal/portal/media;
+    location ^~ /core/static/ {
+        alias /var/www/portal/portal/static/;
     }
 
-    location /core/static {
-        alias /var/www/portal/portal/static;
+    location ^~ /media/  {
+        alias /var/www/portal/cms/media/;
     }
 
-    location /core {
+    location ^~ /static/ {
+        alias /var/www/portal/cms/static/;
+    }
+
+    location ^~ /build/ {
+        alias /var/www/portal/portal/static/;
+    }
+
+    location ^~ /core {
         uwsgi_read_timeout 60s;
         uwsgi_send_timeout 600s;
         uwsgi_pass  portal_core;
         include     /etc/nginx/uwsgi_params;
     }
 
-    location ~ ^/(auth|workbench|tickets|user-news|accounts|api|login|webhooks|googledrive-privacy-policy|public-data|search) {
+    location ~ ^/(auth|workbench|tickets|user-news|accounts|api|login|webhooks|googledrive-privacy-policy|public-data|search)(/?|$) {
         uwsgi_read_timeout 60s;
         uwsgi_send_timeout 600s;
         uwsgi_pass  portal_core;
@@ -127,16 +106,11 @@ server {
         proxy_read_timeout 600;
     }
 
-    location /build {
-        alias /var/www/portal/portal/static;
-    }
-
-    location /static/img/favicon.ico {
-        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
-    }
-
-    location /favicon.ico {
-        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
+    location / {
+        uwsgi_read_timeout 60s;
+        uwsgi_send_timeout 600s;
+        uwsgi_pass  portal_cms;
+        include     /etc/nginx/uwsgi_params;
     }
 
     ## Include any custom location directives


### PR DESCRIPTION
- Moves default portal headers to an nginx snippet, which can be imported for downstream server block consistency.
- Optimizes some nginx location routes.

See for implementation: https://github.com/TACC/Core-Portal-Deployments/pull/196
