### PR TITLE
fix(nginx): delete /favicon.ico location block

### DIFF
--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -48,10 +48,6 @@ server {
         alias /var/www/robots.txt;
     }
 
-    location = /favicon.ico {
-        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
-    }
-
     location = /static/img/favicon.ico {
         alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
     }

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -88,10 +88,6 @@ server {
         alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
     }
 
-    location /favicon.ico {
-        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
-    }
-
     ## Include any custom location directives
     include /etc/nginx/conf.d/*.location.conf;
 }


### PR DESCRIPTION
> [!CAUTION]
> Prematurely merged. I should have tagged it `refactor` not `fix`. Reverting via #83.

## Overview

Removes nginx `/favicon.ico` location blocks so requests reach the Django proxy view added in TACC/Core-CMS#1190.

Rebased onto `main` after #81 (WI-477), which moved favicon handling to early `location =` blocks.

## Related

- coupled to https://github.com/TACC/Core-CMS/pull/1190

## Changes

- **deleted** `location = /favicon.ico` from `default.conf.template` (post–#81 placement)
- **deleted** `location /favicon.ico` from `sad.cms.conf.template`
- **kept** `location = /static/img/favicon.ico` in `default.conf.template` (unchanged URL)

## Testing

1. Deploy `ecep` with:
    - TACC/Core-CMS#1190
    - TACC/Camino#82
    - TACC/Core-Portal-Deployments#199
2. Open https://pprd.ecep.tacc.utexas.edu/favicon.ico
    **or** `curl -si https://pprd.ecep.tacc.utexas.edu/favicon.ico`.
3. Verify favicon
    **or** `200 image/x-icon` from Django.

> [!NOTE]
> https://ecepalliance.org/favicon.ico is TACC favicon.

## UI

<img width="612" height="487" alt="ECEP Favicon Test" src="https://github.com/user-attachments/assets/54a30f26-c88b-4175-8551-0737621c6e25" />