### PR TITLE
Revert "fix(nginx): remove /favicon.ico location block (#82)"

### DIFF
--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -48,6 +48,10 @@ server {
         alias /var/www/robots.txt;
     }
 
+    location = /favicon.ico {
+        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
+    }
+
     location = /static/img/favicon.ico {
         alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
     }

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -88,6 +88,10 @@ server {
         alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
     }
 
+    location /favicon.ico {
+        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
+    }
+
     ## Include any custom location directives
     include /etc/nginx/conf.d/*.location.conf;
 }


### PR DESCRIPTION
This reverts #82, which should be reviewed in tandem with coupled PRs.