### PR TITLE
refactor(nginx): delete favicon nginx intercept (so CMS can do it instead)

### DIFF
--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -48,6 +48,10 @@ server {
         alias /var/www/robots.txt;
     }
 
+    location = /favicon.ico {
+        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
+    }
+
     location = /static/img/favicon.ico {
         alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
     }

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -48,10 +48,6 @@ server {
         alias /var/www/robots.txt;
     }
 
-    location = /favicon.ico {
-        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
-    }
-
     location = /static/img/favicon.ico {
         alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
     }

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -88,6 +88,10 @@ server {
         alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
     }
 
+    location /favicon.ico {
+        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
+    }
+
     ## Include any custom location directives
     include /etc/nginx/conf.d/*.location.conf;
 }

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -88,10 +88,6 @@ server {
         alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
     }
 
-    location /favicon.ico {
-        alias /var/www/portal/cms/static/site_cms/img/favicons/favicon.ico;
-    }
-
     ## Include any custom location directives
     include /etc/nginx/conf.d/*.location.conf;
 }


### PR DESCRIPTION
## Overview

Delete nginx `/favicon.ico` location blocks so requests reach the Django proxy view added in TACC/Core-CMS#1190.

## Related

- review requested via [WP-1310](https://tacc-main.atlassian.net/browse/WP-1310)

> [!CAUTION]
> - coupled to https://github.com/TACC/Core-CMS/pull/1190
> - required by https://github.com/TACC/Core-Portal-Deployments/pull/203

## Changes

- **deleted** `location = /favicon.ico` from `default.conf.template`
- **deleted** `location /favicon.ico` from `sad.cms.conf.template`

> [!NOTE]
> **kept** `location = /static/img/favicon.ico` in `default.conf.template`

## Testing & UI

See https://github.com/TACC/Core-Portal-Deployments/pull/203.