### PR TITLE
fix(nginx): allow syndicatedsearch.goog in CSP connect-src

### DIFF
--- a/conf/nginx/snippets/cep-headers.conf
+++ b/conf/nginx/snippets/cep-headers.conf
@@ -16,7 +16,7 @@ add_header X-Content-Type-Options "nosniff" always;
 # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
 # deployment in Core-Portal-Deployments).
 #
-add_header Content-Security-Policy "form-action 'self'; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra} 'nonce-$cspNonce'" always;
+add_header Content-Security-Policy "form-action 'self'; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://syndicatedsearch.goog https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra} 'nonce-$cspNonce'" always;
 
 add_header X-XSS-Protection "1; mode=block" always;
 add_header Cache-control "no-store";

--- a/conf/nginx/snippets/cep-headers.conf
+++ b/conf/nginx/snippets/cep-headers.conf
@@ -16,6 +16,7 @@ add_header X-Content-Type-Options "nosniff" always;
 # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
 # deployment in Core-Portal-Deployments).
 #
+# `syndicatedsearch.goog` is required or Google Custom Search can throw and fail to render.
 add_header Content-Security-Policy "form-action 'self'; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://syndicatedsearch.goog https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra} 'nonce-$cspNonce'" always;
 
 add_header X-XSS-Protection "1; mode=block" always;

--- a/conf/nginx/snippets/cep-headers.conf
+++ b/conf/nginx/snippets/cep-headers.conf
@@ -15,8 +15,6 @@ add_header X-Content-Type-Options "nosniff" always;
 #   Shared domains (e.g. google analytics) are listed below. Service-specific domains
 # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
 # deployment in Core-Portal-Deployments).
-#
-# `syndicatedsearch.goog` is required or Google Custom Search can throw and fail to render.
 add_header Content-Security-Policy "form-action 'self'; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://syndicatedsearch.goog https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra} 'nonce-$cspNonce'" always;
 
 add_header X-XSS-Protection "1; mode=block" always;

--- a/conf/nginx/snippets/cep-headers.conf
+++ b/conf/nginx/snippets/cep-headers.conf
@@ -15,6 +15,7 @@ add_header X-Content-Type-Options "nosniff" always;
 #   Shared domains (e.g. google analytics) are listed below. Service-specific domains
 # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
 # deployment in Core-Portal-Deployments).
+#
 add_header Content-Security-Policy "form-action 'self'; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://syndicatedsearch.goog https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra} 'nonce-$cspNonce'" always;
 
 add_header X-XSS-Protection "1; mode=block" always;

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -49,6 +49,8 @@ server {
     #
     # CSP 'frame-ancestors':
     #   Allows services to be iframed into TACC portals (e.g. Imageinf iframed into CEP).
+    #
+    # `syndicatedsearch.goog` is required or Google Custom Search can throw and fail to render.
     add_header Content-Security-Policy "connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://syndicatedsearch.goog https://*.tacc.utexas.edu ${csp_connect_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
 
     add_header X-XSS-Protection "1; mode=block" always;

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -49,8 +49,6 @@ server {
     #
     # CSP 'frame-ancestors':
     #   Allows services to be iframed into TACC portals (e.g. Imageinf iframed into CEP).
-    #
-    # `syndicatedsearch.goog` is required or Google Custom Search can throw and fail to render.
     add_header Content-Security-Policy "connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://syndicatedsearch.goog https://*.tacc.utexas.edu ${csp_connect_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
 
     add_header X-XSS-Protection "1; mode=block" always;

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -49,7 +49,7 @@ server {
     #
     # CSP 'frame-ancestors':
     #   Allows services to be iframed into TACC portals (e.g. Imageinf iframed into CEP).
-    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu ${csp_connect_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
+    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://syndicatedsearch.goog https://*.tacc.utexas.edu ${csp_connect_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
 
     add_header X-XSS-Protection "1; mode=block" always;
 


### PR DESCRIPTION
## Overview

Google Custom/Programmable Search Engine has console error, because `connect-src` blocks [domain `syndicatedsearch.goog` that Google's own widget code depends on](https://support.google.com/adsense/answer/14201307).

> [!IMPORTANT]
> I thought this was why search did not render results, but I was wrong.* This might be good to unblock, but it's not necessary, so I close this issue.
> <sub>* Actual problems were (1) outdated WeTeachCS `csp_connect_extra` hack, and (2) the known (by me) oddity Django-CMS-`?edit`-state-often-fails-to-show search-results was causing misleading data for debugging.</sub>

## Related

- [RT #44259](https://tickets.tacc.utexas.edu/Ticket/Display.html?id=44259)
- https://github.com/TACC/Core-Portal-Deployments/pull/212
- required by https://github.com/TACC/Core-Portal-Deployments/pull/215

## Changes

- **added** `syndicatedsearch.goog` to the `connect-src` directive in:
    - `cep-headers.conf`
    - `sad.cms.conf.template`

## Testing

1. Deploy to a portal on `sad.cms.conf.template` (e.g. CraftLAB) and load `/search/?q=test`
2. Confirm the console no longer shows the blocked `syndicatedsearch.goog` request or the `cse_element__en.js` uncaught TypeError
3. Confirm search results render
4. Repeat on a portal using `default.conf.template` / `cep-headers.conf`

> [!TIP]
> Tested successfully on WTCS via https://github.com/TACC/Core-Portal-Deployments/pull/212 and https://github.com/TACC/Core-Portal-Deployments/pull/215.

## Notes

1. **`ep1.adtrafficquality.google`:** I let our sites block this on purpose, because it is only used for Google's ad-quality checks, and who wants ads anyway, and education sites can opt out of ads, so it doesn't matter.

2. **`syndicatedsearch.goog`:** Before this fix, some sites seemed fine and others crashed, even with the exact same setup — for example, [CIPP](https://cipacific.org/) was fine, [CraftLAB](https://craftlab.tacc.utexas.edu/) crashed. That's because Google's search widget sometimes calls this domain in a way our old rule allowed, and sometimes in a way old rule blocked — that was luck, not anything about the site. Adding this domain to the allow list fixes it for good, no matter which way Google's code happens to call it.