### PR TITLE
task/WI-472: Review CSP differences between service.conf.template and default.conf.template

### DIFF
--- a/conf/nginx/snippets/cep-headers.conf
+++ b/conf/nginx/snippets/cep-headers.conf
@@ -16,7 +16,9 @@ add_header X-Content-Type-Options "nosniff" always;
 # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
 # deployment in Core-Portal-Deployments).
 #
-add_header Content-Security-Policy "form-action 'self'; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra} 'nonce-$cspNonce'" always;
+add_header Content-Security-Policy-Report-Only "default-src 'self'; form-action 'self'; script-src 'self' https://cdn.jsdelivr.net ${csp_script_extra} 'nonce-$cspNonce'; style-src 'self' 'unsafe-inline' ${csp_style_extra} 'nonce-$cspNonce'; font-src 'self' ${csp_font_extra}; img-src 'self' https://cdn.jsdelivr.net blob: ${csp_img_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra}; report-uri /csp-report;" always;
+
+add_header Report-To '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://portal.tacc.utexas.edu/csp-report"}]}' always;
 
 add_header X-XSS-Protection "1; mode=block" always;
 add_header Cache-control "no-store";

--- a/conf/nginx/snippets/cep-headers.conf
+++ b/conf/nginx/snippets/cep-headers.conf
@@ -16,9 +16,8 @@ add_header X-Content-Type-Options "nosniff" always;
 # are appended via $csp_connect_extra, defined in csp-map.http.conf (overridable per
 # deployment in Core-Portal-Deployments).
 #
-add_header Content-Security-Policy-Report-Only "default-src 'self'; form-action 'self'; script-src 'self' https://cdn.jsdelivr.net ${csp_script_extra} 'nonce-$cspNonce'; style-src 'self' 'unsafe-inline' ${csp_style_extra} 'nonce-$cspNonce'; font-src 'self' ${csp_font_extra}; img-src 'self' https://cdn.jsdelivr.net blob: ${csp_img_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra}; report-uri /csp-report;" always;
-
-add_header Report-To '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://portal.tacc.utexas.edu/csp-report"}]}' always;
+add_header Content-Security-Policy-Report-Only "default-src 'self'; form-action 'self'; script-src 'self' https://cdn.jsdelivr.net ${csp_script_extra} 'nonce-$cspNonce'; style-src 'self' 'unsafe-inline' ${csp_style_extra} 'nonce-$cspNonce'; font-src 'self' ${csp_font_extra}; img-src 'self' https://cdn.jsdelivr.net blob: ${csp_img_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra}; report-uri /csp-report/;" always;
+add_header Report-To '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://${server_name}.tacc.utexas.edu/csp-report"}]}' always;
 
 add_header X-XSS-Protection "1; mode=block" always;
 add_header Cache-control "no-store";

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -49,8 +49,8 @@ server {
     #
     # CSP 'frame-ancestors':
     #   Allows services to be iframed into TACC portals (e.g. Imageinf iframed into CEP).
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; form-action 'self'; script-src 'self' https://cdn.jsdelivr.net ${csp_script_extra} 'nonce-$cspNonce'; style-src 'self' 'unsafe-inline' ${csp_style_extra} 'nonce-$cspNonce'; font-src 'self' ${csp_font_extra}; img-src 'self' https://cdn.jsdelivr.net blob: ${csp_img_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra}; report-uri /csp-report;" always;
-    add_header Report-To '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://portal.tacc.utexas.edu/csp-report"}]}' always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; form-action 'self'; script-src 'self' https://cdn.jsdelivr.net ${csp_script_extra} 'nonce-$cspNonce'; style-src 'self' 'unsafe-inline' ${csp_style_extra} 'nonce-$cspNonce'; font-src 'self' ${csp_font_extra}; img-src 'self' https://cdn.jsdelivr.net blob: ${csp_img_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra}; report-uri /csp-report/;" always;
+    add_header Report-To '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://${server_name}.tacc.utexas.edu/csp-report"}]}' always;
 
     add_header X-XSS-Protection "1; mode=block" always;
 

--- a/conf/nginx/templates/sad.cms.conf.template
+++ b/conf/nginx/templates/sad.cms.conf.template
@@ -49,7 +49,8 @@ server {
     #
     # CSP 'frame-ancestors':
     #   Allows services to be iframed into TACC portals (e.g. Imageinf iframed into CEP).
-    add_header Content-Security-Policy "connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu ${csp_connect_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; form-action 'self'; script-src 'self' https://cdn.jsdelivr.net ${csp_script_extra} 'nonce-$cspNonce'; style-src 'self' 'unsafe-inline' ${csp_style_extra} 'nonce-$cspNonce'; font-src 'self' ${csp_font_extra}; img-src 'self' https://cdn.jsdelivr.net blob: ${csp_img_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra}; report-uri /csp-report;" always;
+    add_header Report-To '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://portal.tacc.utexas.edu/csp-report"}]}' always;
 
     add_header X-XSS-Protection "1; mode=block" always;
 

--- a/conf/nginx/templates/service.conf.template
+++ b/conf/nginx/templates/service.conf.template
@@ -42,7 +42,9 @@ server {
     #
     # CSP 'frame-ancestors':
     #   Allows services to be iframed into TACC portals (e.g. Imageinf iframed into CEP).
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' ${csp_script_extra}; style-src 'self' 'unsafe-inline' ${csp_style_extra}; font-src 'self' ${csp_font_extra}; img-src 'self' blob: ${csp_img_extra}; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io ${csp_connect_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; form-action 'self';" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; form-action 'self'; script-src 'self' https://cdn.jsdelivr.net ${csp_script_extra} 'nonce-$cspNonce'; style-src 'self' 'unsafe-inline' ${csp_style_extra} 'nonce-$cspNonce'; font-src 'self' ${csp_font_extra}; img-src 'self' https://cdn.jsdelivr.net blob: ${csp_img_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra}; report-uri /csp-report;" always;
+    add_header Report-To '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://portal.tacc.utexas.edu/csp-report"}]}' always;
+
     add_header X-XSS-Protection "1; mode=block" always;
 
     ## Include any custom location directives

--- a/conf/nginx/templates/service.conf.template
+++ b/conf/nginx/templates/service.conf.template
@@ -42,8 +42,8 @@ server {
     #
     # CSP 'frame-ancestors':
     #   Allows services to be iframed into TACC portals (e.g. Imageinf iframed into CEP).
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; form-action 'self'; script-src 'self' https://cdn.jsdelivr.net ${csp_script_extra} 'nonce-$cspNonce'; style-src 'self' 'unsafe-inline' ${csp_style_extra} 'nonce-$cspNonce'; font-src 'self' ${csp_font_extra}; img-src 'self' https://cdn.jsdelivr.net blob: ${csp_img_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra}; report-uri /csp-report;" always;
-    add_header Report-To '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://portal.tacc.utexas.edu/csp-report"}]}' always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; form-action 'self'; script-src 'self' https://cdn.jsdelivr.net ${csp_script_extra} 'nonce-$cspNonce'; style-src 'self' 'unsafe-inline' ${csp_style_extra} 'nonce-$cspNonce'; font-src 'self' ${csp_font_extra}; img-src 'self' https://cdn.jsdelivr.net blob: ${csp_img_extra}; frame-src 'self' ${csp_frame_extra}; frame-ancestors 'self' https://*.tacc.utexas.edu; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://pypi.org https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.tacc.utexas.edu https://*.tapis.io https://*.github.com ${csp_connect_extra}; report-uri /csp-report/;" always;
+    add_header Report-To '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://${server_name}.tacc.utexas.edu/csp-report"}]}' always;
 
     add_header X-XSS-Protection "1; mode=block" always;
 


### PR DESCRIPTION
## Overview
Review CSP differences between service.conf.template and default.conf.template.  We have three nginx templates in Camino. Two share the same permissive CSP (default.conf.template and sad.cms.template); one has a comprehensive CSP (service.conf.template). 

Is service.conf.template reasonable, or is it overly aggressive (e.g. forcing every service deployment to enumerate CDN allowances)? Does default.conf.template need to change? (Same question applies to sad.cms.template since its CSP is identical.) Is the csp-map file approach working? Are there alternatives? Or better way to make this maintainable?

## Related

* [WI-472](https://tacc-main.atlassian.net/browse/WI-472)
* https://github.com/TACC/Core-Portal/pull/1349

## Changes
Adding nginx configuration to report violations of content-security-policy to a report url. Adds a Content-Security-Policy in report-only mode ahead of a future enforcing rollout, plus a violation-reporting endpoint. Updates headers to include script-src, style-src, img-src, font-src, connect-src, frame-src, frame-ancestors, base-uri, object-src, and form-action. Uses the existing $cspNonce variable (already defined elsewhere in this config) on script-src/style-src.

## Testing

1. Run `nginx -t` in the nginx container and make sure it passes
2. Run a curl against /csp-report/ and make sure it proxies to portal_core and returns 204 (once the companion Portal PR above is deployed).
3. Confirm via browser devtools that the header is present and CSP warnings appear in console without blocking page functionality. 

## Notes
We would want to deploy this to staging and then run for a week, then deploy a follow-up PR to turn off `Report-Only`
